### PR TITLE
Check that the Docker daemon is running

### DIFF
--- a/docker/delete.sh
+++ b/docker/delete.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Check that the Docker daemon is running
+if ! docker ps > /dev/null; then exit 1; fi
+
 BASEDIR=$(dirname "$0")
 
 read -p "Are you wish to delete Torq including data? (y/n)" -n 1 -r

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -22,7 +22,7 @@ stty echo
 printf "\n"
 
 printf "\n"
-echo Please set a web ui password
+echo Please set a web UI password
 stty -echo
 printf "UI Password: "
 read UIPASSWORD
@@ -85,6 +85,6 @@ echo "${Red}${DELETE_COMMAND}${NC}\t (WARNING: This command deletes Torq _includ
 echo "${Green}Optional:${NC} you can add these scripts to your PATH by running:"
 echo "sudo ln -s ${TORQDIR}/* /usr/local/bin/"
 
-echo "\nTry it out! Start Torq now with:"
+echo "\nTry it out now! Make sure the Docker daemon is running, and then start Torq with:"
 echo "${Green}${TORQDIR}/${START_COMMAND}${NC}"
 echo "\n"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Check that the Docker daemon is running
+if ! docker ps > /dev/null; then exit 1; fi
+
 BASEDIR=$(dirname "$0")
 
 docker pull lncapital/torq

--- a/docker/stop.sh
+++ b/docker/stop.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Check that the Docker daemon is running
+if ! docker ps > /dev/null; then exit 1; fi
+
 BASEDIR=$(dirname "$0")
 
 docker-compose -f $BASEDIR/docker-compose.yml down

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Check that the Docker daemon is running
+if ! docker ps > /dev/null; then exit 1; fi
+
 BASEDIR=$(dirname "$0")
 
 docker-compose -f $BASEDIR/docker-compose.yml down


### PR DESCRIPTION

If the Docker daemon is not running when doing `start-torq`, the script goes on anyway, eventually timing out:

```shell
Using default tag: latest
Cannot connect to the Docker daemon at unix:///Users/username/.docker/run/docker.sock. Is the docker daemon running?
Cannot connect to the Docker daemon at unix:///Users/username/.docker/run/docker.sock. Is the docker daemon running?
Torq is starting, please wait
```

The other commands show similar behaviour.

This PR fixes that by checking if the Docker daemon is running. If it’s not, the script exits showing the error message  above  once. The fix is a one-liner, so I ended up copy-pasting it into all scripts instead of sourcing it from an external file (which would require downloading another file, changing access permissions. If you do prefer that approach, I don‘t mind updating my PR.

This also works if Docker is not installed at all, in which case we get `docker: command not found` and `docker-compose: command not found`.

Please note that I’ve just tested this on macOS.