### PR TITLE
Improvements to the install procedure

### DIFF
--- a/docker/example-docker-compose.yml
+++ b/docker/example-docker-compose.yml
@@ -9,9 +9,9 @@ services:
       - --db.host
       - db
       - --db.password
-      - <YourDBPassword> # Must match db password below
+      - "<YourDBPassword>" # Must match db password below
       - --torq.password
-      - <YourUIPassword> # Set password here to connect to login to the web ui
+      - "<YourUIPassword>" # Set password here to connect to login to the web ui
       - --torq.port
       - "<YourPort>"
       - start
@@ -20,7 +20,7 @@ services:
   db:
     image: "timescale/timescaledb:latest-pg14"
     environment:
-      POSTGRES_PASSWORD: <YourDBPassword> # Must match db password set above
+      POSTGRES_PASSWORD: "<YourDBPassword>" # Must match db password set above
     volumes:
       - torq_db:/var/lib/postgresql/data
 volumes:

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,44 +1,56 @@
 #!/usr/bin/env bash
 
-
 echo Configuring docker-compose file
 
+# Set Torq help commands directory
+
 printf "\n"
-echo Please where you want to add the Torq help commands
-stty echo
-printf "Directory (default: ~/.torq):"
-read TORQDIR
-stty echo
+echo Please specify where you want to add the Torq help commands
+read -p "Directory (default: ~/.torq): " TORQDIR
 eval TORQDIR="${TORQDIR:=$HOME/.torq}"
 echo $TORQDIR
 printf "\n"
 
+# Set database password
+
 printf "\n"
-echo Please set a database password
 stty -echo
-printf "DB Password: "
-read DBPASSWORD
+read -p "Please set a database password: " DBPASSWORD
+
+while [[ -z "$DBPASSWORD" ]]; do
+  printf "\n"
+  read -p "The password cannot be empty, please try again: " DBPASSWORD
+done
+
 stty echo
 printf "\n"
 
-printf "\n"
-echo Please set a web ui password
-stty -echo
-printf "UI Password: "
-read UIPASSWORD
-stty echo
-printf "\n"
-printf "\n"
+# Set web UI password
 
 printf "\n"
-echo Please choose a port for the web UI.
+stty -echo
+read -p "Please set a web UI password: " UIPASSWORD
+
+while [[ -z "$UIPASSWORD" ]]; do
+  printf "\n"
+  read -p "The password cannot be empty, please try again: " UIPASSWORD
+done
+
+stty echo
+printf "\n"
+
+# Set web UI port number
+
+printf "\n"
+echo Please choose a port number for the web UI.
 echo NB! Umbrel users needs to use a different port than 8080. Try 8081.
-stty echo
-printf "Port (default: 8080):"
-read UI_PORT
-stty echo
+read -p "Port number (default: 8080): " UI_PORT
 eval UI_PORT="${UI_PORT:=8080}"
-printf "\n"
+
+while [[ ! $UI_PORT =~ ^[0-9]+$ ]] || [[ $UI_PORT -lt 1 ]] || [[ $UI_PORT -gt 65535 ]]; do
+    read -p "Invalid port number. Please enter a valid port number from 1 through 65535: " UI_PORT
+done
+
 printf "\n"
 
 mkdir -p $TORQDIR


### PR DESCRIPTION
This fixes two issues in the install script:

* Make sure that both the database and web UI passwords are non-empty
* Make sure that the port number is in the valid range

It also puts quotes around the passwords in `example-docker-compose.yml` to avoid the yml become invalid if the password only contains digits.