### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X github.com/lncapital/torq/bui
 FROM node:buster-slim as frontend-builder
 WORKDIR /app
 COPY web/package*.json ./
-RUN npm install --legacy-peer-deps
+RUN npm install --legacy-peer-deps && npm cache clean --force;
 COPY web/. .
 RUN TSX_COMPILE_ON_ERROR=true ESLINT_NO_DEV_ERRORS=true npm run build
 
@@ -22,8 +22,7 @@ FROM debian:buster-slim
 COPY --from=backend-builder /app/torq /app/
 COPY --from=frontend-builder /app/build /app/web/build
 RUN useradd -ms /bin/bash torq
-RUN apt-get -y update
-RUN apt-get -y install ca-certificates bash
+RUN apt-get -y update && apt-get -y --no-install-recommends install ca-certificates bash && rm -rf /var/lib/apt/lists/*;
 RUN update-ca-certificates
 ENV GIN_MODE=release
 WORKDIR /app


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.
* I put `apt-get update` and `apt-get install` in a single layer to optimize the layers and reduce the number of unneeded files.
* I added `rm -rf /var/lib/apt/lists/*` after `apt-get install` which removes unnecessary files and reduces the size of the image.


Impact on the image size:
* Image size before repair: 149.25 MB
* Image size after repair: 132.23 MB
* Difference: 17.02 MB (11.4%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,