### PR TITLE
Use headers to control caching of locale file

### DIFF
--- a/web/src/services/i18n/i18nAPI.js
+++ b/web/src/services/i18n/i18nAPI.js
@@ -1,9 +1,12 @@
 import { langUrl } from "config/i18nConfig";
+const noCacheHeader = new Headers();
+noCacheHeader.append("pragma", "no-cache");
+noCacheHeader.append("cache-control", "no-cache");
 
 export function fetchTranslations(lang) {
   return new Promise((resolve) => {
-    fetch(langUrl.replace("{lang}", lang))
-      .then(response => response.json())
-      .then(data => resolve(data));
+    fetch(langUrl.replace("{lang}", lang), { method: "get", headers: noCacheHeader })
+      .then((response) => response.json())
+      .then((data) => resolve(data));
   });
 }


### PR DESCRIPTION
Added no cache headers to i18nApi when fetching locale file, the browser will negotiate with the server to see if there is a newer version.