### PR TITLE
Updated channels page to use the view name as the title 

### DIFF
--- a/web/src/features/templates/tablePageTemplate/TablePageTemplate.tsx
+++ b/web/src/features/templates/tablePageTemplate/TablePageTemplate.tsx
@@ -17,12 +17,13 @@ type TablePageTemplateProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   breadcrumbs?: Array<any>;
   children?: React.ReactNode;
+  onNameChange?: (title: string) => void;
 };
 
 export default function TablePageTemplate(props: TablePageTemplateProps) {
   return (
     <div className={classNames(styles.contentWrapper)}>
-      <PageTitle breadcrumbs={props.breadcrumbs} title={props.title}>
+      <PageTitle breadcrumbs={props.breadcrumbs} title={props.title} onNameChange={props.onNameChange}>
         {props.titleContent}
       </PageTitle>
 


### PR DESCRIPTION
Changes:

- Display view title
- Allow editing of the view title in the view