### PR TITLE
Fix settings page layout

### DIFF
--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -118,8 +118,8 @@ function Settings() {
   return (
     <Page>
       <React.Fragment>
-        <div>
-          <div className={styles.center}>
+        <div className={styles.settingsPage}>
+          <div className={styles.settingsColumn}>
             <div>
               <h3>{t.settings}</h3>
 

--- a/web/src/features/settings/settings.module.css
+++ b/web/src/features/settings/settings.module.css
@@ -4,6 +4,7 @@
   width: 100%;
 }
 .settingsColumn {
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -24,4 +25,5 @@
 
 .footer {
   text-align: center;
+  margin-top: auto;
 }

--- a/web/src/features/settings/settings.module.css
+++ b/web/src/features/settings/settings.module.css
@@ -1,8 +1,15 @@
-.center {
-  display: grid;
-  justify-content: center;
-  grid-template-columns: minmax(300px, 440px);
-  grid-row-gap: 30px;
+.settingsPage {
+  height: 100%;
+  overflow: scroll;
+  width: 100%;
+}
+.settingsColumn {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-width: 300px;
+  max-width: 440px;
+  gap: 30px;
   padding-bottom: 20px;
 }
 .settingsForm {
@@ -17,9 +24,4 @@
 
 .footer {
   text-align: center;
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  max-width: 440px;
-  height: 50px;
 }

--- a/web/src/layout/page.module.scss
+++ b/web/src/layout/page.module.scss
@@ -1,6 +1,6 @@
 .page {
   width: 100%;
-  padding: 20px 10px;
+  padding: 20px 10px 10px 10px;
 }
 
 .headContainer {

--- a/web/src/layout/page.module.scss
+++ b/web/src/layout/page.module.scss
@@ -1,4 +1,5 @@
 .page {
+  width: 100%;
   padding: 20px 10px;
 }
 


### PR DESCRIPTION
The settings page was a broken layout. This was made obvious by a floating footer. This PR fixes the layout which then enables simpler footer CSS.