### PR TITLE
Fix update channel policy errors

### DIFF
--- a/internal/channels/handlers.go
+++ b/internal/channels/handlers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lncapital/torq/internal/tags"
+	"github.com/rs/zerolog/log"
 
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
@@ -130,7 +131,10 @@ func updateChannelsHandler(c *gin.Context, lightningRequestChannel chan interfac
 
 	response := SetRoutingPolicyWithTimeout(requestBody, lightningRequestChannel)
 	if response.Status != commons.Active {
-		server_errors.WrapLogAndSendServerError(c, errors.New(response.Error), "Update channel/s policy")
+		err := errors.New(response.Error)
+		c.JSON(http.StatusInternalServerError, server_errors.SingleServerError(err.Error()))
+		err = errors.Wrap(err, "Problem when setting routing policy")
+		log.Error().Err(err).Send()
 		return
 	}
 

--- a/web/src/components/errors/ErrorSummary.tsx
+++ b/web/src/components/errors/ErrorSummary.tsx
@@ -2,7 +2,6 @@ import Note, { NoteType } from "features/note/Note";
 import { ErrorCircle20Regular as ErrorIcon } from "@fluentui/react-icons";
 import { FormErrors, replaceMessageMergeTags } from "./errors";
 import useTranslations from "services/i18n/useTranslations";
-import { useState } from "react";
 
 type errorSummaryType = {
   title?: string;
@@ -11,25 +10,25 @@ type errorSummaryType = {
 
 const ErrorSummary = ({ errors, title }: errorSummaryType) => {
   const { t } = useTranslations();
-  const [serverErrorsState, setServerErrorsState] = useState([] as string[]);
+  const serverErrors = [] as string[];
   if (errors && errors.server) {
     for (const error of errors.server) {
       if (error.code) {
         const translatedError = t.errors[error.code];
         const mergedError = replaceMessageMergeTags(translatedError, error.attributes);
-        setServerErrorsState([...serverErrorsState, mergedError]);
+        serverErrors.push(mergedError);
         continue;
       }
       // Bit of a hack to only show the top most error rather than all the wrapped errors
-      setServerErrorsState([...serverErrorsState, (error.description ?? "").split(":")[0]]);
+      serverErrors.push((error.description ?? "").split(":")[0]);
     }
   }
   return (
     <>
       {(errors.server || errors.fields) && (
         <Note icon={<ErrorIcon />} title={title ?? "Error"} noteType={NoteType.error}>
-          {serverErrorsState &&
-            serverErrorsState.map((error, index) => {
+          {serverErrors &&
+            serverErrors.map((error, index) => {
               return <p key={index}>{error}</p>;
             })}
           {errors.fields && <p>See form error{Object.keys(errors.fields).length > 1 && <>s</>}</p>}


### PR DESCRIPTION
It was a bit of a mess with massive double red Xs and with difficult to understand generic error messages.

Front end code is now using some common error handling code. The style has been updated to use the shared error summary component and the backend has been updated to send specific error messages rather than just always replying with a generic error.