### PR TITLE
Fixed when deleting a node channels will now show channels correctly.

### DIFF
--- a/cmd/torq/internal/torqsrv/server.go
+++ b/cmd/torq/internal/torqsrv/server.go
@@ -45,7 +45,8 @@ func Start(port int, apiPswd string, cookiePath string, db *sqlx.DB,
 	lightningRequestChannel chan interface{},
 	rebalanceRequestChannel chan commons.RebalanceRequest,
 	serviceChannel chan commons.ServiceChannelMessage,
-	autoLogin bool) error {
+	autoLogin bool,
+	serviceEventChannel chan commons.ServiceEvent) error {
 
 	r := gin.Default()
 
@@ -58,7 +59,7 @@ func Start(port int, apiPswd string, cookiePath string, db *sqlx.DB,
 		return errors.Wrap(err, "Creating Gin Session")
 	}
 
-	registerRoutes(r, db, apiPswd, cookiePath, webSocketResponseChannel, broadcaster, lightningRequestChannel, rebalanceRequestChannel, serviceChannel, autoLogin)
+	registerRoutes(r, db, apiPswd, cookiePath, webSocketResponseChannel, broadcaster, lightningRequestChannel, rebalanceRequestChannel, serviceChannel, autoLogin, serviceEventChannel)
 
 	fmt.Println("Listening on port " + strconv.Itoa(port))
 
@@ -122,7 +123,8 @@ func registerRoutes(r *gin.Engine, db *sqlx.DB, apiPwd string, cookiePath string
 	lightningRequestChannel chan interface{},
 	rebalanceRequestChannel chan commons.RebalanceRequest,
 	serviceChannel chan commons.ServiceChannelMessage,
-	autoLogin bool) {
+	autoLogin bool,
+	serviceEventChannel chan commons.ServiceEvent) {
 
 	r.Use(gzip.Gzip(gzip.DefaultCompression))
 	applyCors(r)
@@ -242,7 +244,7 @@ func registerRoutes(r *gin.Engine, db *sqlx.DB, apiPwd string, cookiePath string
 
 		settingRoutes := api.Group("settings")
 		{
-			settings.RegisterSettingRoutes(settingRoutes, db, serviceChannel)
+			settings.RegisterSettingRoutes(settingRoutes, db, serviceChannel, serviceEventChannel)
 		}
 
 		api.GET("/ping", func(c *gin.Context) {

--- a/cmd/torq/internal/torqsrv/server.go
+++ b/cmd/torq/internal/torqsrv/server.go
@@ -45,8 +45,7 @@ func Start(port int, apiPswd string, cookiePath string, db *sqlx.DB,
 	lightningRequestChannel chan interface{},
 	rebalanceRequestChannel chan commons.RebalanceRequest,
 	serviceChannel chan commons.ServiceChannelMessage,
-	autoLogin bool,
-	serviceEventChannel chan commons.ServiceEvent) error {
+	autoLogin bool) error {
 
 	r := gin.Default()
 
@@ -59,7 +58,7 @@ func Start(port int, apiPswd string, cookiePath string, db *sqlx.DB,
 		return errors.Wrap(err, "Creating Gin Session")
 	}
 
-	registerRoutes(r, db, apiPswd, cookiePath, webSocketResponseChannel, broadcaster, lightningRequestChannel, rebalanceRequestChannel, serviceChannel, autoLogin, serviceEventChannel)
+	registerRoutes(r, db, apiPswd, cookiePath, webSocketResponseChannel, broadcaster, lightningRequestChannel, rebalanceRequestChannel, serviceChannel, autoLogin)
 
 	fmt.Println("Listening on port " + strconv.Itoa(port))
 
@@ -123,8 +122,7 @@ func registerRoutes(r *gin.Engine, db *sqlx.DB, apiPwd string, cookiePath string
 	lightningRequestChannel chan interface{},
 	rebalanceRequestChannel chan commons.RebalanceRequest,
 	serviceChannel chan commons.ServiceChannelMessage,
-	autoLogin bool,
-	serviceEventChannel chan commons.ServiceEvent) {
+	autoLogin bool) {
 
 	r.Use(gzip.Gzip(gzip.DefaultCompression))
 	applyCors(r)
@@ -244,7 +242,7 @@ func registerRoutes(r *gin.Engine, db *sqlx.DB, apiPwd string, cookiePath string
 
 		settingRoutes := api.Group("settings")
 		{
-			settings.RegisterSettingRoutes(settingRoutes, db, serviceChannel, serviceEventChannel)
+			settings.RegisterSettingRoutes(settingRoutes, db, serviceChannel)
 		}
 
 		api.GET("/ping", func(c *gin.Context) {

--- a/cmd/torq/torq.go
+++ b/cmd/torq/torq.go
@@ -258,7 +258,7 @@ func main() {
 
 			if err = torqsrv.Start(c.Int("torq.port"), c.String("torq.password"), c.String("torq.cookie-path"),
 				db, webSocketResponseChannelGlobal, broadcasterGlobal, lightningRequestChannelGlobal, rebalanceRequestChannelGlobal,
-				serviceChannelGlobal, c.Bool("torq.auto-login"), serviceEventChannelGlobal); err != nil {
+				serviceChannelGlobal, c.Bool("torq.auto-login")); err != nil {
 				return errors.Wrap(err, "Starting torq webserver")
 			}
 
@@ -553,10 +553,6 @@ func processServiceEvents(db *sqlx.DB, serviceChannel chan commons.ServiceChanne
 				log.Info().Msg("Torq is booting.")
 			case commons.Initializing:
 				log.Info().Msg("Torq is initialising.")
-
-				//reset
-				commons.ResetManagedNodeCache()
-				commons.ResetManagedChannelStateCache()
 
 				err := settings.InitializeManagedSettingsCache(db)
 				if err != nil {

--- a/cmd/torq/torq.go
+++ b/cmd/torq/torq.go
@@ -258,7 +258,7 @@ func main() {
 
 			if err = torqsrv.Start(c.Int("torq.port"), c.String("torq.password"), c.String("torq.cookie-path"),
 				db, webSocketResponseChannelGlobal, broadcasterGlobal, lightningRequestChannelGlobal, rebalanceRequestChannelGlobal,
-				serviceChannelGlobal, c.Bool("torq.auto-login")); err != nil {
+				serviceChannelGlobal, c.Bool("torq.auto-login"), serviceEventChannelGlobal); err != nil {
 				return errors.Wrap(err, "Starting torq webserver")
 			}
 
@@ -553,6 +553,11 @@ func processServiceEvents(db *sqlx.DB, serviceChannel chan commons.ServiceChanne
 				log.Info().Msg("Torq is booting.")
 			case commons.Initializing:
 				log.Info().Msg("Torq is initialising.")
+
+				//reset
+				commons.ResetManagedNodeCache()
+				commons.ResetManagedChannelStateCache()
+
 				err := settings.InitializeManagedSettingsCache(db)
 				if err != nil {
 					log.Error().Err(err).Msg("Failed to obtain settings for ManagedSettings cache.")

--- a/internal/channels/database.go
+++ b/internal/channels/database.go
@@ -301,7 +301,8 @@ func getClosedChannels(db *sqlx.DB, network int) ([]Channel, error) {
 	err := db.Select(&channels, `
 		SELECT c.* FROM Channel c
 		JOIN Node n on n.node_id = c.First_Node_Id
-	 	WHERE n.network =$1 AND c.Status_id in (100,101,102,103,104,105)
+		JOIN Node_Connection_Details ncd on ncd.node_id = n.node_id
+	 	WHERE ncd.status_id != 3 AND n.network =$1 AND c.Status_id in (100,101,102,103,104,105)
 	`, network)
 
 	if err != nil {
@@ -320,7 +321,8 @@ func getPendingChannels(db *sqlx.DB, network int) ([]Channel, error) {
 	err := db.Select(&channels, `
 		SELECT c.* FROM Channel c
 		JOIN Node n on n.node_id = c.First_Node_Id
-	 	WHERE n.network =$1 AND c.Status_id in (0,2)
+		JOIN Node_Connection_Details ncd on ncd.node_id = n.node_id
+	 	WHERE ncd.status_id != 3 AND n.network =$1 AND n.network =$1 AND c.Status_id in (0,2)
 	`, network)
 
 	if err != nil {

--- a/pkg/commons/managedChannelState.go
+++ b/pkg/commons/managedChannelState.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lightningnetwork/lnd/lnrpc"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/exp/maps"
 )
 
 var ManagedChannelStateChannel = make(chan ManagedChannelState) //nolint:gochecknoglobals
@@ -179,11 +180,6 @@ func ManagedChannelStateCache(ch chan ManagedChannelState, ctx context.Context, 
 		case <-ctx.Done():
 			return
 		case managedChannelState := <-ch:
-			if managedChannelState.Type == RESET_CHANNELSTATE_CACHE {
-				channelStateSettingsByChannelIdCache = make(map[int]map[int]ManagedChannelStateSettings, 0)
-				channelStateSettingsStatusCache = make(map[int]Status, 0)
-				channelStateSettingsDeactivationTimeCache = make(map[int]time.Time, 0)
-			}
 			processManagedChannelStateSettings(managedChannelState,
 				channelStateSettingsStatusCache, channelStateSettingsByChannelIdCache,
 				channelStateSettingsDeactivationTimeCache, channelBalanceEventChannel)
@@ -590,6 +586,10 @@ func processManagedChannelStateSettings(managedChannelState ManagedChannelState,
 		} else {
 			log.Error().Msgf("Received HTLC channel balance update for uncached node with nodeId: %v", managedChannelState.HtlcEvent.NodeId)
 		}
+	case RESET_CHANNELSTATE_CACHE:
+		maps.Clear(channelStateSettingsByChannelIdCache)
+		maps.Clear(channelStateSettingsStatusCache)
+		maps.Clear(channelStateSettingsDeactivationTimeCache)
 	}
 }
 

--- a/pkg/commons/managedNode.go
+++ b/pkg/commons/managedNode.go
@@ -30,6 +30,7 @@ const (
 	READ_ALL_CHANNEL_NODEIDS
 	READ_ALL_CHANNEL_PUBLICKEYS
 	READ_NODE_SETTING
+	RESET_MANAGED_NODE_CACHE
 )
 
 type ManagedNode struct {
@@ -68,6 +69,14 @@ func ManagedNodeCache(ch chan ManagedNode, ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case managedNode := <-ch:
+			if managedNode.Type == RESET_MANAGED_NODE_CACHE {
+				allTorqNodeIdCache = make(map[Chain]map[Network]map[string]int, 0)
+				nodeSettingsByNodeIdCache = make(map[int]ManagedNodeSettings, 0)
+				activeTorqNodeIdCache = make(map[Chain]map[Network]map[string]int, 0)
+				channelNodeIdCache = make(map[Chain]map[Network]map[string]int, 0)
+				allChannelNodeIdCache = make(map[Chain]map[Network]map[string]int, 0)
+				torqNodeNameByNodeIdCache = make(map[int]string, 0)
+			}
 			processManagedNode(managedNode, allTorqNodeIdCache, activeTorqNodeIdCache,
 				channelNodeIdCache, allChannelNodeIdCache, nodeSettingsByNodeIdCache, torqNodeNameByNodeIdCache)
 		}
@@ -539,4 +548,10 @@ func GetNodeSettingsByNodeId(nodeId int) ManagedNodeSettings {
 	}
 	ManagedNodeChannel <- managedNode
 	return <-nodeResponseChannel
+}
+
+func ResetManagedNodeCache() {
+	ManagedNodeChannel <- ManagedNode{
+		Type: RESET_MANAGED_NODE_CACHE,
+	}
 }

--- a/pkg/commons/managedNode.go
+++ b/pkg/commons/managedNode.go
@@ -2,6 +2,7 @@ package commons
 
 import (
 	"context"
+	"golang.org/x/exp/maps"
 
 	"github.com/rs/zerolog/log"
 )
@@ -69,14 +70,6 @@ func ManagedNodeCache(ch chan ManagedNode, ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case managedNode := <-ch:
-			if managedNode.Type == RESET_MANAGED_NODE_CACHE {
-				allTorqNodeIdCache = make(map[Chain]map[Network]map[string]int, 0)
-				nodeSettingsByNodeIdCache = make(map[int]ManagedNodeSettings, 0)
-				activeTorqNodeIdCache = make(map[Chain]map[Network]map[string]int, 0)
-				channelNodeIdCache = make(map[Chain]map[Network]map[string]int, 0)
-				allChannelNodeIdCache = make(map[Chain]map[Network]map[string]int, 0)
-				torqNodeNameByNodeIdCache = make(map[int]string, 0)
-			}
 			processManagedNode(managedNode, allTorqNodeIdCache, activeTorqNodeIdCache,
 				channelNodeIdCache, allChannelNodeIdCache, nodeSettingsByNodeIdCache, torqNodeNameByNodeIdCache)
 		}
@@ -348,6 +341,13 @@ func processManagedNode(managedNode ManagedNode, allTorqNodeIdCache map[Chain]ma
 				Status:    Inactive,
 			}
 		}
+	case RESET_MANAGED_NODE_CACHE:
+		maps.Clear(allTorqNodeIdCache)
+		maps.Clear(nodeSettingsByNodeIdCache)
+		maps.Clear(activeTorqNodeIdCache)
+		maps.Clear(channelNodeIdCache)
+		maps.Clear(allChannelNodeIdCache)
+		maps.Clear(torqNodeNameByNodeIdCache)
 	}
 }
 

--- a/web/src/apiSlice.ts
+++ b/web/src/apiSlice.ts
@@ -178,7 +178,7 @@ export const torqApi = createApi({
         method: "POST",
         body: nodeConfiguration,
       }),
-      invalidatesTags: ["nodeConfigurations", "channels"],
+      invalidatesTags: ["nodeConfigurations", "channels", "channelsClosed", "channelsPending"],
     }),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     updateNodeConfiguration: builder.mutation<any, FormData>({
@@ -195,7 +195,7 @@ export const torqApi = createApi({
         url: `settings/nodeConnectionDetails/${nodeConfiguration.nodeId}/${nodeConfiguration.status}`,
         method: "PUT",
       }),
-      invalidatesTags: ["nodeConfigurations", "channels"],
+      invalidatesTags: ["nodeConfigurations", "channels", "channelsClosed", "channelsPending"],
     }),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     updateNodePingSystemStatus: builder.mutation<any, { nodeId: number; pingSystem: number; statusId: number }>({


### PR DESCRIPTION
Backend will reset node and channelstate caches and run through the Initializing process to rehydrate data.

Pending and Closed channels query amended to exclude deleted nodes