### PR TITLE
confirm before deleting workflows

### DIFF
--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -167,6 +167,7 @@
   "bootstrapping": "Bootstrapping",
   "workflow": "Workflow",
   "workflows": "Workflows",
+  "confirmDeleteWorkflow": "Are you sure you want to delete this workflow?",
   "nodes": "Nodes",
   "stage": "Stage",
   "StageTrigger": "Stage Trigger",

--- a/web/src/components/table/cells/workflow/WorkflowCell.tsx
+++ b/web/src/components/table/cells/workflow/WorkflowCell.tsx
@@ -21,6 +21,9 @@ function WorkflowCell(props: WorkflowCell) {
   const [updateWorkflow] = useUpdateWorkflowMutation();
 
   function archiveWorkflow() {
+    if (!confirm(t.confirmDeleteWorkflow)) {
+      return;
+    }
     mixpanel.track("Workflow Archive", {
       workflowId: props.workflowId,
       workflowVersionId: props.workflowVersionId,


### PR DESCRIPTION
Adds a confirmation message before deleting workflows. Preventing "ooops" moments... 

Fixes https://github.com/lncapital/torq/issues/488

<img width="1039" alt="Screenshot 2023-03-06 at 17 58 32" src="https://user-images.githubusercontent.com/647617/223178791-e10a2e2e-514d-4b82-8a7f-972f3509a931.png">
