### PR TITLE
First date to node settings

### DIFF
--- a/database/migrations/000088_add_node_start_date.up.psql
+++ b/database/migrations/000088_add_node_start_date.up.psql
@@ -1,0 +1,9 @@
+ALTER TABLE node_connection_details
+ADD COLUMN node_start_date TIMESTAMPTZ;
+
+-- Populate the added value for existing nodes
+UPDATE node_connection_details
+SET node_start_date = (SELECT tx.timestamp
+    FROM tx
+    WHERE tx.node_id = node_connection_details.node_id
+    ORDER BY block_height ASC LIMIT 1)

--- a/internal/settings/database.go
+++ b/internal/settings/database.go
@@ -497,11 +497,11 @@ func SetNodeConnectionDetails(db *sqlx.DB, ncd NodeConnectionDetails) (NodeConne
 		UPDATE node_connection_details
 		SET implementation = $1, name = $2, grpc_address = $3, tls_file_name = $4, tls_data = $5,
 		    macaroon_file_name = $6, macaroon_data = $7, status_id = $8, ping_system = $9, updated_on = $10,
-			custom_settings = $11
-		WHERE node_id = $12;`,
+			custom_settings = $11, node_start_date = $12
+		WHERE node_id = $13;`,
 		ncd.Implementation, ncd.Name, ncd.GRPCAddress, ncd.TLSFileName, ncd.TLSDataBytes,
 		ncd.MacaroonFileName, ncd.MacaroonDataBytes, ncd.Status, ncd.PingSystem, ncd.UpdatedOn,
-		ncd.CustomSettings, ncd.NodeId)
+		ncd.CustomSettings, ncd.NodeStartDate, ncd.NodeId)
 	if err != nil {
 		return ncd, errors.Wrap(err, database.SqlExecutionError)
 	}
@@ -544,11 +544,11 @@ func addNodeConnectionDetails(db *sqlx.DB, ncd NodeConnectionDetails) (NodeConne
 	_, err := db.Exec(`
 		INSERT INTO node_connection_details
 		    (node_id, name, implementation, grpc_address, tls_file_name, tls_data, macaroon_file_name, macaroon_data,
-		     status_id, ping_system, custom_settings, created_on, updated_on)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13);`,
+		     status_id, ping_system, custom_settings, created_on, updated_on, node_start_date)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14);`,
 		ncd.NodeId, ncd.Name, ncd.Implementation, ncd.GRPCAddress, ncd.TLSFileName, ncd.TLSDataBytes,
 		ncd.MacaroonFileName, ncd.MacaroonDataBytes, ncd.Status, ncd.PingSystem, ncd.CustomSettings,
-		ncd.CreateOn, ncd.UpdatedOn)
+		ncd.CreateOn, ncd.UpdatedOn, ncd.NodeStartDate)
 	if err != nil {
 		return ncd, errors.Wrap(err, database.SqlExecutionError)
 	}

--- a/internal/settings/nodeConnectionDetails.go
+++ b/internal/settings/nodeConnectionDetails.go
@@ -28,6 +28,7 @@ type NodeConnectionDetails struct {
 	CustomSettings    core.NodeConnectionDetailCustomSettings `json:"customSettings" db:"custom_settings"`
 	CreateOn          time.Time                               `json:"createdOn" db:"created_on"`
 	UpdatedOn         *time.Time                              `json:"updatedOn"  db:"updated_on"`
+	NodeStartDate     *time.Time                              `json:"nodeStartDate"  db:"node_start_date"`
 }
 
 func GetNodeIdByGRPC(db *sqlx.DB, grpcAddress string) (int, error) {
@@ -70,6 +71,11 @@ func AddNodeToDB(db *sqlx.DB, implementation core.Implementation,
 		return ncd, nil
 	}
 
+	nodeStartDate, err := getNodeStartDateFromLndNode(grpcAddress, tlsDataBytes, macaroonDataBytes)
+	if err != nil {
+		return NodeConnectionDetails{}, errors.Wrap(err, "Getting node start date from lnd node")
+	}
+
 	nodeConnectionDetailsData := NodeConnectionDetails{
 		NodeId:            nodeId,
 		Name:              fmt.Sprintf("Node_%v", nodeId),
@@ -79,6 +85,7 @@ func AddNodeToDB(db *sqlx.DB, implementation core.Implementation,
 		TLSDataBytes:      tlsDataBytes,
 		MacaroonDataBytes: macaroonDataBytes,
 		CreateOn:          time.Now().UTC(),
+		NodeStartDate:     nodeStartDate,
 	}
 	ncd, err := addNodeConnectionDetails(db, nodeConnectionDetailsData)
 	if err != nil {

--- a/testutil/testdb.go
+++ b/testutil/testdb.go
@@ -251,9 +251,9 @@ func addNode(db *sqlx.DB, testPublicKey string, cancel context.CancelFunc) (int,
 
 func addNodeConnectionDetails(db *sqlx.DB, testNodeId int, cancel context.CancelFunc) error {
 	_, err := db.Exec(`INSERT INTO node_connection_details
-			(node_id, name, implementation, status_id, ping_system, custom_settings, created_on, updated_on)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`,
-		testNodeId, fmt.Sprintf("Node_%v", testNodeId), core.LND, core.Active, 0, 0, time.Now().UTC(), time.Now().UTC())
+			(node_id, name, implementation, status_id, ping_system, custom_settings, created_on, updated_on, node_start_date)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);`,
+		testNodeId, fmt.Sprintf("Node_%v", testNodeId), core.LND, core.Active, 0, 0, time.Now().UTC(), time.Now().UTC(), nil)
 	if err != nil {
 		cancel()
 		return errors.Wrapf(err, "Inserting default node_connection_details for testing with nodeId: %v", testNodeId)

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -170,6 +170,7 @@
   "nodeName": "Node Name",
   "grpcAddress": "GRPC Address (IP or Tor)",
   "tlsCertificate": "TLS Certificate",
+  "nodeStartDate": "Starting date of the node (leave empty to get automatically)",
   "macaroon": "Macaroon",
   "summary": "Summary",
   "forwards": "Forwards",
@@ -440,12 +441,12 @@
       "closing": "Closing"
     }
   },
-  "summaryNode" : {
-    "online" : "Online",
-    "offline" : "Disabled"
+  "summaryNode": {
+    "online": "Online",
+    "offline": "Disabled"
   },
-  "peers" : "Peers",
-  "peerNode" : "Peer Node",
+  "peers": "Peers",
+  "peerNode": "Peer Node",
   "peersPage": {
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/web/src/apiTypes.ts
+++ b/web/src/apiTypes.ts
@@ -36,6 +36,7 @@ export interface nodeConfiguration {
   status: number;
   pingSystem: number;
   customSettings: number;
+  nodeStartDate?: Date;
 }
 
 export interface stringMap<T> {

--- a/web/src/features/settings/NodeSettings.tsx
+++ b/web/src/features/settings/NodeSettings.tsx
@@ -153,7 +153,7 @@ const NodeSettings = React.forwardRef(function NodeSettings(
       pingSystem: 0,
       name: "",
       customSettings: 0,
-      nodeStartDate: undefined
+      nodeStartDate: undefined,
     } as nodeConfiguration);
   };
 
@@ -425,7 +425,7 @@ const NodeSettings = React.forwardRef(function NodeSettings(
     } else {
       setNodeConfigurationState({ ...nodeConfigurationState, nodeStartDate: undefined });
     }
-  }
+  };
 
   const toggleCustomSettingsStateNow = (key: string) => {
     setCustomSettingsSaveEnabledState(true);
@@ -450,8 +450,7 @@ const NodeSettings = React.forwardRef(function NodeSettings(
       return format(new Date(date.valueOf()), "yyyy-MM-dd");
     }
     return "";
-  }
-
+  };
 
   const implementationOptions: Array<SelectOption> = [{ value: "0", label: "LND" }];
 
@@ -625,10 +624,10 @@ const NodeSettings = React.forwardRef(function NodeSettings(
                 {addMode
                   ? "Add Node"
                   : nodeConfigurationState.status == 1
-                    ? "Disable node to update"
-                    : saveEnabledState
-                      ? "Save node details"
-                      : "Saving..."}
+                  ? "Disable node to update"
+                  : saveEnabledState
+                  ? "Save node details"
+                  : "Saving..."}
               </Button>
               {!addMode && (
                 <div className={styles.toggleSettings}>


### PR DESCRIPTION
Implemented this https://github.com/lncapital/torq/issues/121

Instead of getting the starting date of the node from payments/forwards, I used the first on-chain transaction of the node.

It is possible to set the date manually, but if left empty, it is fetched automatically.

I did a migration where for existing nodes the date is fetched from tx table.