### PR TITLE
balance cell now uses remote and local capacity as total amount

### DIFF
--- a/web/src/components/table/cells/balance/BalanceCell.tsx
+++ b/web/src/components/table/cells/balance/BalanceCell.tsx
@@ -5,15 +5,15 @@ import cellStyles from "components/table/cells/cell.module.scss";
 import styles from "./balance_cell.module.scss";
 
 export type BalanceCellProps = {
-  capacity: number;
   remote: number;
+  capacity: number;
   local: number;
   totalCell?: boolean;
   className?: string;
 };
 
-const calculateAvailableBalance = (amount: number, capacity: number) => {
-  const calculate = amount / capacity;
+const calculateAvailableBalance = (local: number, remote: number) => {
+  const calculate = local / (local + remote);
   return format(".2%")(calculate);
 };
 
@@ -46,13 +46,13 @@ const BalanceCell = (props: BalanceCellProps) => {
       <div className={classNames(styles.bar)}>
         <div
           className={classNames(styles.percentage)}
-          style={{ width: calculateAvailableBalance(props.local, props.capacity) }}
+          style={{ width: calculateAvailableBalance(props.local, props.remote) }}
         />
       </div>
       <div className={classNames(styles.capacity)}>
-        <div className={classNames(styles.remote)}>{calculateAvailableBalance(props.remote, props.capacity)}</div>
+        <div className={classNames(styles.remote)}>{calculateAvailableBalance(props.remote, props.local)}</div>
         <div className={classNames(styles.total)}>{formatAmount(props.capacity)}</div>
-        <div className={classNames(styles.local)}>{calculateAvailableBalance(props.local, props.capacity)}</div>
+        <div className={classNames(styles.local)}>{calculateAvailableBalance(props.local, props.remote)}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
fixes https://github.com/lncapital/internal-torq-roadmap/issues/248

Note, I used the channel capacity, not remote + local balance, for the capacity number bellow the bar. I think this is more as the user then will see the expected channel size in the table. 

![balance](https://user-images.githubusercontent.com/647617/234591523-345e9e37-86ff-48d5-b10c-0b4be8498636.jpg)
