### PR TITLE
246 - fixed channels sort to stop bouncing on updates

### DIFF
--- a/web/src/features/channels/channelsDefaults.ts
+++ b/web/src/features/channels/channelsDefaults.ts
@@ -7,6 +7,7 @@ import {
 } from "features/channels/channelsColumns.generated";
 import { FilterInterface } from "features/sidebar/sections/filter/filter";
 import { ColumnMetaData } from "features/table/types";
+import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 
 const defaultColumns: Array<keyof channel> = [
   "peerAlias",
@@ -33,10 +34,16 @@ export const ChannelsFilterTemplate: FilterInterface = {
   key: "capacity",
 };
 
-export const ChannelsSortTemplate: { key: keyof channel; direction: "desc" | "asc" } = {
-  key: "peerAlias",
-  direction: "asc",
-};
+export const ChannelsSortTemplate: OrderBy[] = [
+  {
+    key: "peerAlias",
+    direction: "asc",
+  },
+  {
+    key: "shortChannelId",
+    direction: "desc",
+  },
+];
 
 export const DefaultChannelsView: ViewResponse<channel> = {
   page: "channel",
@@ -44,7 +51,7 @@ export const DefaultChannelsView: ViewResponse<channel> = {
   view: {
     title: "Draft View",
     columns: DefaultChannelsColumns,
-    sortBy: [ChannelsSortTemplate],
+    sortBy: ChannelsSortTemplate,
   },
 };
 

--- a/web/src/features/channelsClosed/channelsClosedDefaults.ts
+++ b/web/src/features/channelsClosed/channelsClosedDefaults.ts
@@ -8,6 +8,7 @@ import {
   ChannelsClosedFilterableColumns,
   ChannelsClosedSortableColumns,
 } from "./channelsClosedColumns.generated";
+import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 
 const defaultColumns: Array<keyof ChannelClosed> = [
   "peerAlias",
@@ -37,10 +38,12 @@ export const ChannelsClosedFilterTemplate: FilterInterface = {
   key: "capacity",
 };
 
-export const ChannelsClosedSortTemplate: { key: keyof ChannelClosed; direction: "desc" | "asc" } = {
-  key: "closedOnSecondsDelta",
-  direction: "desc",
-};
+export const ChannelsClosedSortTemplate: Array<OrderBy> = [
+  {
+    key: "closedOnSecondsDelta",
+    direction: "desc",
+  },
+];
 
 export const DefaultClosedChannelsView: ViewResponse<ChannelClosed> = {
   page: "channelsClosed",
@@ -48,7 +51,7 @@ export const DefaultClosedChannelsView: ViewResponse<ChannelClosed> = {
   view: {
     title: "Closed Channels",
     columns: DefaultChannelsClosedColumns,
-    sortBy: [ChannelsClosedSortTemplate],
+    sortBy: ChannelsClosedSortTemplate,
   },
 };
 

--- a/web/src/features/channelsPending/channelsPendingDefaults.ts
+++ b/web/src/features/channelsPending/channelsPendingDefaults.ts
@@ -8,6 +8,7 @@ import {
   ChannelsPendingSortableColumns,
 } from "features/channelsPending/channelsPendingColumns.generated";
 import { ChannelPending } from "./channelsPendingTypes";
+import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 
 const defaultColumns: Array<keyof ChannelPending> = [
   "peerAlias",
@@ -42,10 +43,12 @@ export const ChannelsPendingFilterTemplate: FilterInterface = {
   key: "capacity",
 };
 
-export const ChannelsPendingSortTemplate: { key: keyof ChannelPending; direction: "desc" | "asc" } = {
-  key: "peerAlias",
-  direction: "asc",
-};
+export const ChannelsPendingSortTemplate: Array<OrderBy> = [
+  {
+    key: "peerAlias",
+    direction: "asc",
+  },
+];
 
 export const DefaultPendingChannelsView: ViewResponse<ChannelPending> = {
   page: "channelsPending",
@@ -53,7 +56,7 @@ export const DefaultPendingChannelsView: ViewResponse<ChannelPending> = {
   view: {
     title: "Pending Channels",
     columns: DefaultChannelsPendingColumns,
-    sortBy: [ChannelsPendingSortTemplate],
+    sortBy: ChannelsPendingSortTemplate,
   },
 };
 

--- a/web/src/features/forwards/forwardsDefaults.ts
+++ b/web/src/features/forwards/forwardsDefaults.ts
@@ -2,7 +2,7 @@ import { AndClause, FilterInterface } from "features/sidebar/sections/filter/fil
 import { ViewResponse } from "features/viewManagement/types";
 import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 import { Forward } from "features/forwards/forwardsTypes";
-import { AllForwardsColumns } from "features/forwards/forwardsColumns.generated"
+import { AllForwardsColumns } from "features/forwards/forwardsColumns.generated";
 
 export const ForwardsFilterTemplate: FilterInterface = {
   funcName: "gte",
@@ -22,7 +22,7 @@ const defaultColumns: Array<keyof Forward> = [
   "capacity",
 ];
 
-export const ForwardsSortByTemplate: OrderBy = { key: "revenueOut", direction: "desc" };
+export const ForwardsSortByTemplate: Array<OrderBy> = [{ key: "revenueOut", direction: "desc" }];
 
 export const DefaultForwardsColumns = AllForwardsColumns.filter((c) => defaultColumns.includes(c.key));
 
@@ -33,7 +33,7 @@ export const DefaultForwardsView: ViewResponse<Forward> = {
     title: "Draft View",
     filters: new AndClause().toJSON(),
     columns: DefaultForwardsColumns,
-    sortBy: [ForwardsSortByTemplate],
+    sortBy: ForwardsSortByTemplate,
     groupBy: "channels",
   },
 };

--- a/web/src/features/forwards/forwardsDefaults.ts
+++ b/web/src/features/forwards/forwardsDefaults.ts
@@ -34,6 +34,6 @@ export const DefaultForwardsView: ViewResponse<Forward> = {
     filters: new AndClause().toJSON(),
     columns: DefaultForwardsColumns,
     sortBy: ForwardsSortByTemplate,
-    groupBy: "channels",
+    groupBy: "channel",
   },
 };

--- a/web/src/features/peers/peersDefaults.ts
+++ b/web/src/features/peers/peersDefaults.ts
@@ -4,6 +4,7 @@ import { Peer } from "features/peers/peersTypes";
 import { FilterInterface } from "features/sidebar/sections/filter/filter";
 import { ColumnMetaData } from "features/table/types";
 import { AllPeersColumns, PeersFilterableColumns, PeersSortableColumns } from "./peersColumns.generated";
+import { OrderBy } from "../sidebar/sections/sort/SortSection";
 
 const defaultColumns: Array<keyof Peer> = ["peerAlias", "connectionStatus", "nodeName", "pubKey", "tags"];
 
@@ -22,10 +23,12 @@ export const PeersFilterTemplate: FilterInterface = {
   key: "value",
 };
 
-export const PeersSortTemplate: { key: keyof Peer; direction: "desc" | "asc" } = {
-  key: "peerAlias",
-  direction: "desc",
-};
+export const PeersSortTemplate: Array<OrderBy> = [
+  {
+    key: "peerAlias",
+    direction: "desc",
+  },
+];
 
 export const DefaultPeersView: ViewResponse<Peer> = {
   page: "peers",
@@ -33,7 +36,7 @@ export const DefaultPeersView: ViewResponse<Peer> = {
   view: {
     title: "Peers",
     columns: DefaultPeersColumns,
-    sortBy: [PeersSortTemplate],
+    sortBy: PeersSortTemplate,
   },
 };
 

--- a/web/src/features/sidebar/sections/sort/SortSection.tsx
+++ b/web/src/features/sidebar/sections/sort/SortSection.tsx
@@ -175,7 +175,7 @@ type SortSectionProps<T> = {
   viewIndex: number;
   columns: Array<ColumnMetaData<T>>;
   sortBy?: Array<OrderBy>;
-  defaultSortBy: OrderBy;
+  defaultSortBy: Array<OrderBy>;
 };
 
 function SortSection<T>(props: SortSectionProps<T>) {
@@ -199,6 +199,7 @@ function SortSection<T>(props: SortSectionProps<T>) {
   }, [props.columns]);
 
   const handleAddSort = () => {
+    const defaultSortPlaceholder = props.defaultSortBy[0];
     if (view) {
       track(`View Add Sort By`, {
         viewPage: props.page,
@@ -208,11 +209,11 @@ function SortSection<T>(props: SortSectionProps<T>) {
         viewSortedBy: (view.sortBy || []).map((s) => {
           return { key: s.key, direction: s.direction };
         }),
-        viewNewSortKey: props.defaultSortBy.key,
-        viewNewSortDirection: props.defaultSortBy.direction,
+        viewNewSortKey: defaultSortPlaceholder.key,
+        viewNewSortDirection: defaultSortPlaceholder.direction,
       });
     }
-    dispatch(addSortBy({ page: props.page, viewIndex: props.viewIndex, sortBy: props.defaultSortBy }));
+    dispatch(addSortBy({ page: props.page, viewIndex: props.viewIndex, sortBy: defaultSortPlaceholder }));
   };
 
   const droppableContainerId = "sort-list-droppable";
@@ -232,6 +233,7 @@ function SortSection<T>(props: SortSectionProps<T>) {
     }
 
     if (view) {
+      const defaultSortPlaceholder = props.defaultSortBy[0];
       track(`View Update Sort By`, {
         viewPage: props.page,
         viewIndex: props.viewIndex,
@@ -240,8 +242,8 @@ function SortSection<T>(props: SortSectionProps<T>) {
         viewSortedBy: (view.sortBy || []).map((s) => {
           return { key: s.key, direction: s.direction };
         }),
-        viewNewSortKey: props.defaultSortBy.key,
-        viewNewSortDirection: props.defaultSortBy.direction,
+        viewNewSortKey: defaultSortPlaceholder.key,
+        viewNewSortDirection: defaultSortPlaceholder.direction,
       });
     }
 

--- a/web/src/features/transact/Invoices/invoiceDefaults.ts
+++ b/web/src/features/transact/Invoices/invoiceDefaults.ts
@@ -8,6 +8,7 @@ import {
 } from "features/transact/Invoices/invoicesColumns.generated";
 import { ColumnMetaData } from "features/table/types";
 import { FilterInterface } from "features/sidebar/sections/filter/filter";
+import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 
 const defaultKeys: Array<keyof Invoice> = [
   "creationDate",
@@ -31,10 +32,12 @@ export const FilterableInvoiceColumns = AllInvoicesColumns.filter((column: Colum
   return InvoicesFilterableColumns.includes(column.key);
 });
 
-export const InvoiceSortTemplate: { key: keyof Invoice; direction: "desc" | "asc" } = {
-  key: "creationDate",
-  direction: "desc",
-};
+export const InvoiceSortTemplate: Array<OrderBy> = [
+  {
+    key: "creationDate",
+    direction: "desc",
+  },
+];
 
 export const InvoiceFilterTemplate: FilterInterface = {
   key: "value",
@@ -49,6 +52,6 @@ export const DefaultInvoiceView: ViewResponse<Invoice> = {
   view: {
     title: "Draft View",
     columns: DefaultInvoicesColumns,
-    sortBy: [InvoiceSortTemplate],
+    sortBy: InvoiceSortTemplate,
   },
 };

--- a/web/src/features/transact/OnChain/onChainDefaults.ts
+++ b/web/src/features/transact/OnChain/onChainDefaults.ts
@@ -5,8 +5,9 @@ import { FilterInterface } from "features/sidebar/sections/filter/filter";
 import {
   AllOnChainTransactionsColumns,
   OnChainTransactionsSortableColumns,
-  OnChainTransactionsFilterableColumns
+  OnChainTransactionsFilterableColumns,
 } from "features/transact/OnChain/onChainColumns.generated";
+import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 
 const defaultColumns: Array<keyof OnChainTx> = [
   "date",
@@ -28,10 +29,12 @@ export const FilterableOnChainColumns = AllOnChainTransactionsColumns.filter((co
   OnChainTransactionsFilterableColumns.includes(column.key)
 );
 
-export const OnChainSortTemplate: { key: keyof OnChainTx; direction: "desc" | "asc" } = {
-  key: "date",
-  direction: "desc",
-};
+export const OnChainSortTemplate: Array<OrderBy> = [
+  {
+    key: "date",
+    direction: "desc",
+  },
+];
 
 export const OnChainFilterTemplate: FilterInterface = {
   funcName: "gte",
@@ -46,6 +49,6 @@ export const DefaultOnChainView: ViewResponse<OnChainTx> = {
   view: {
     title: "Draft View",
     columns: DefaultOnChainColumns,
-    sortBy: [OnChainSortTemplate],
+    sortBy: OnChainSortTemplate,
   },
 };

--- a/web/src/features/transact/Payments/paymentDefaults.ts
+++ b/web/src/features/transact/Payments/paymentDefaults.ts
@@ -2,7 +2,12 @@ import { ColumnMetaData } from "features/table/types";
 import { Payment } from "features/transact/Payments/types";
 import { ViewResponse } from "features/viewManagement/types";
 import { FilterCategoryType, FilterInterface } from "features/sidebar/sections/filter/filter";
-import { AllPaymentsColumns, PaymentsSortableColumns, PaymentsFilterableColumns } from "features/transact/Payments/paymentsColumns.generated";
+import {
+  AllPaymentsColumns,
+  PaymentsSortableColumns,
+  PaymentsFilterableColumns,
+} from "features/transact/Payments/paymentsColumns.generated";
+import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 
 const defaultColumns: Array<keyof Payment> = [
   "date",
@@ -49,10 +54,12 @@ export const FailureReasonLabels = new Map<string, string>([
   ["FAILURE_REASON_UNKNOWN", "Unknown"],
 ]);
 
-export const PaymentsSortTemplate: { key: keyof Payment; direction: "desc" | "asc" } = {
-  key: "date",
-  direction: "desc",
-};
+export const PaymentsSortTemplate: Array<OrderBy> = [
+  {
+    key: "date",
+    direction: "desc",
+  },
+];
 
 export const ActivePaymentsColumns: Array<ColumnMetaData<Payment>> = AllPaymentsColumns.filter((item) => {
   return defaultColumns.includes(item.key);
@@ -64,6 +71,6 @@ export const DefaultPaymentView: ViewResponse<Payment> = {
   view: {
     title: "Draft View",
     columns: ActivePaymentsColumns,
-    sortBy: [PaymentsSortTemplate],
+    sortBy: PaymentsSortTemplate,
   },
 };

--- a/web/src/features/viewManagement/ViewsSidebar.tsx
+++ b/web/src/features/viewManagement/ViewsSidebar.tsx
@@ -28,7 +28,7 @@ type ViewSidebarProps<T> = {
   allColumns: Array<ColumnMetaData<T>>;
   filterableColumns: ColumnMetaData<T>[];
   sortableColumns: ColumnMetaData<T>[];
-  sortByTemplate: OrderBy;
+  sortByTemplate: Array<OrderBy>;
   filterTemplate: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   enableGroupBy?: boolean;
 };


### PR DESCRIPTION
Refactored code to allow default sort template to be an array to allow chaining of sortable properties.

ChannelDefaults changed to be sorted by PeerAlias and then by ShortChannelId to stop the ordering changing when auto updating