### PR TITLE
Add tags column to closed channels and pending channels pages

### DIFF
--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -324,9 +324,11 @@ func getTableViewColumnDefinitions() []tableViewColumnDefinition {
 			visualType: "TagsCell",
 			valueType:  "tag",
 			pages: map[TableViewPage]int{
-				PageChannels: 4,
-				PageForwards: 7,
-				PagePeers:    6,
+				PageChannels:        4,
+				PageChannelsClosed:  19,
+				PageChannelsPending: 23,
+				PageForwards:        7,
+				PagePeers:           6,
 			},
 		},
 		{

--- a/web/src/features/channelsClosed/channelsClosedCellRenderer.tsx
+++ b/web/src/features/channelsClosed/channelsClosedCellRenderer.tsx
@@ -4,13 +4,16 @@ import { ChannelClosed } from "features/channelsClosed/channelsClosedTypes";
 import DefaultCellRenderer from "features/table/DefaultCellRenderer";
 import ChannelCell from "components/table/cells/channelCell/ChannelCell";
 import LongTextCell from "components/table/cells/longText/LongTextCell";
+import TagsCell from "components/table/cells/tags/TagsCell";
+import { GroupByOptions } from "features/viewManagement/types";
 export default function channelsClosedCellRenderer(
   row: ChannelClosed,
   rowIndex: number,
   column: ColumnMetaData<ChannelClosed>,
   columnIndex: number,
   isTotalsRow?: boolean,
-  maxRow?: ChannelClosed
+  maxRow?: ChannelClosed,
+  groupedBy?: GroupByOptions
 ): JSX.Element {
   switch (column.key) {
     case "peerAlias":
@@ -48,6 +51,18 @@ export default function channelsClosedCellRenderer(
           />
         );
       }
+      break;
+    case "tags":
+      return (
+        <TagsCell
+          channelTags={row.channelTags}
+          peerTags={row.peerTags}
+          key={"tagsCell" + rowIndex}
+          channelId={row.channelId}
+          nodeId={row.peerNodeId}
+          displayChannelTags={groupedBy !== "peer"}
+        />
+      );
       break;
   }
 

--- a/web/src/features/channelsClosed/channelsClosedColumns.generated.ts
+++ b/web/src/features/channelsClosed/channelsClosedColumns.generated.ts
@@ -121,6 +121,12 @@ export const AllChannelClosedColumns: ColumnMetaData<ChannelClosed>[] = [
 			{ label: "Abandoned Closed", value: "Abandoned Closed" },
 		],
 	},
+	{
+		heading: "Tags",
+		type: "TagsCell",
+		key: "tags",
+		valueType: "tag",
+	},
 ];
 
 
@@ -169,4 +175,5 @@ export const ChannelsClosedFilterableColumns: Array<keyof ChannelClosed> = [
 	"closedOnSecondsDelta",
 	"nodeName",
 	"status",
+	"tags",
 ];

--- a/web/src/features/channelsClosed/channelsClosedDefaults.ts
+++ b/web/src/features/channelsClosed/channelsClosedDefaults.ts
@@ -13,6 +13,7 @@ import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 const defaultColumns: Array<keyof ChannelClosed> = [
   "peerAlias",
   "capacity",
+  "tags",
   "closedOn",
   "fundedOn",
   "status",

--- a/web/src/features/channelsClosed/channelsClosedTypes.ts
+++ b/web/src/features/channelsClosed/channelsClosedTypes.ts
@@ -1,6 +1,6 @@
 import { channel } from "features/channels/channelsTypes";
 
-export type ChannelClosed = Omit<channel, "tag"> & {
+export type ChannelClosed = channel & {
   pubKey: string;
   status: string;
   closingNodeName: string;

--- a/web/src/features/channelsPending/channelsPendingColumns.generated.ts
+++ b/web/src/features/channelsPending/channelsPendingColumns.generated.ts
@@ -121,6 +121,12 @@ export const AllChannelPendingColumns: ColumnMetaData<ChannelPending>[] = [
 		key: "closedOnSecondsDelta",
 		valueType: "duration",
 	},
+	{
+		heading: "Tags",
+		type: "TagsCell",
+		key: "tags",
+		valueType: "tag",
+	},
 ];
 
 
@@ -169,4 +175,5 @@ export const ChannelsPendingFilterableColumns: Array<keyof ChannelPending> = [
 	"status",
 	"closedOn",
 	"closedOnSecondsDelta",
+	"tags",
 ];

--- a/web/src/features/channelsPending/channelsPendingDefaults.ts
+++ b/web/src/features/channelsPending/channelsPendingDefaults.ts
@@ -13,6 +13,7 @@ import { OrderBy } from "features/sidebar/sections/sort/SortSection";
 const defaultColumns: Array<keyof ChannelPending> = [
   "peerAlias",
   "capacity",
+  "tags",
   "status",
   "fundingTransactionHash",
   "closingTransactionHash",

--- a/web/src/features/viewManagement/types.ts
+++ b/web/src/features/viewManagement/types.ts
@@ -19,7 +19,16 @@ export type ViewResponse<T> = {
   dirty?: boolean;
 };
 
-export type TableResponses = Forward | OnChainTx | Payment | Invoice | ExpandedTag | channel | workflowListItem;
+export type TableResponses =
+  | Forward
+  | OnChainTx
+  | Payment
+  | Invoice
+  | ExpandedTag
+  | channel
+  | workflowListItem
+  | ChannelClosed
+  | ChannelPending;
 
 export type AllViewsResponse = {
   forwards: Array<ViewResponse<Forward>>;

--- a/web/src/pages/tags/tagsApi.ts
+++ b/web/src/pages/tags/tagsApi.ts
@@ -41,7 +41,16 @@ export const tagsApi = torqApi.injectEndpoints({
         method: "POST",
         body: tagChannel,
       }),
-      invalidatesTags: ["tags", "tag", "channels", "tagsForChannel", "channelHistory", "forwards"],
+      invalidatesTags: [
+        "tags",
+        "tag",
+        "channels",
+        "channelsClosed",
+        "channelsPending",
+        "tagsForChannel",
+        "channelHistory",
+        "forwards",
+      ],
     }),
     tagNode: builder.mutation<void, TagNodeRequest>({
       query: (tagNode) => ({
@@ -49,7 +58,17 @@ export const tagsApi = torqApi.injectEndpoints({
         method: "POST",
         body: tagNode,
       }),
-      invalidatesTags: ["tags", "tag", "tagsForNode", "channels", "channelHistory", "forwards", "peers"],
+      invalidatesTags: [
+        "tags",
+        "tag",
+        "tagsForNode",
+        "channels",
+        "channelsClosed",
+        "channelsPending",
+        "channelHistory",
+        "forwards",
+        "peers",
+      ],
     }),
     untagNode: builder.mutation<void, TagNodeRequest>({
       query: (tagNode) => ({
@@ -57,7 +76,17 @@ export const tagsApi = torqApi.injectEndpoints({
         method: "POST",
         body: tagNode,
       }),
-      invalidatesTags: ["tags", "tag", "tagsForNode", "channels", "channelHistory", "forwards", "peers"],
+      invalidatesTags: [
+        "tags",
+        "tag",
+        "tagsForNode",
+        "channels",
+        "channelsClosed",
+        "channelsPending",
+        "channelHistory",
+        "forwards",
+        "peers",
+      ],
     }),
     untagChannel: builder.mutation<void, TagChannelRequest>({
       query: (tagChannel) => ({
@@ -65,7 +94,16 @@ export const tagsApi = torqApi.injectEndpoints({
         method: "POST",
         body: tagChannel,
       }),
-      invalidatesTags: ["tags", "tag", "channels", "tagsForChannel", "channelHistory", "forwards"],
+      invalidatesTags: [
+        "tags",
+        "tag",
+        "channels",
+        "channelsClosed",
+        "channelsPending",
+        "tagsForChannel",
+        "channelHistory",
+        "forwards",
+      ],
     }),
     getChannelTags: builder.query<Array<TagResponse>, number>({
       query: (channelId) => `tags/channel/${channelId}`,


### PR DESCRIPTION
This issue: https://github.com/lncapital/torq/issues/467

Added the Tags column as the third column by default on Pending and Closed channels pages.